### PR TITLE
Delete Author

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ ORIENTATION_DOMAIN=orientation.dev
 ORIENTATION_LOGO=default_logo.svg
 ORIENTATION_FAVICON=default_favicon.png
 
+# IDs for administrator users separated by :, for now all they can do is delete authors.
+ADMINISTRATORS="1:2:42"
+
 # Rails configuration
 SECRET_KEY_BASE=
 DATABASE_NAME=orientation_development

--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,8 @@ ORIENTATION_DOMAIN=orientation.dev
 ORIENTATION_LOGO=default_logo.svg
 ORIENTATION_FAVICON=default_favicon.png
 
-# IDs for administrator users separated by :, for now all they can do is delete authors.
-ADMINISTRATORS="1:2:42"
+# IDs for administrator users separated by commas , for now all they can do is delete authors.
+ADMINISTRATORS="1,2,42"
 
 # Rails configuration
 SECRET_KEY_BASE=

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -60,13 +60,17 @@ class AuthorsController < ApplicationController
   def destroy
     @author = User.find(params[:id])
 
-    if current_user != @author
-      @author.replace_and_destroy!(current_user)
-      flash[:notice] = "You deleted #{@author.name}."
-      redirect_to authors_path
-    else
+    if !current_user.administrator?
+      flash[:notice] = "You are not an administrator."
+      redirect_to author_path(@author)
+    elsif current_user == @author
       flash[:notice] = "You cannot delete yourself."
       redirect_to author_path(@author)
+    else
+      replacement_author = current_user
+      @author.replace_and_destroy!(replacement_author)
+      flash[:notice] = "You deleted #{@author.name} and re-assigned articles to #{replacement_author.name}."
+      redirect_to authors_path
     end
   end
 

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -61,7 +61,7 @@ class AuthorsController < ApplicationController
     @author = User.find(params[:id])
 
     if current_user != @author
-      @author.destroy!
+      @author.replace_and_destroy!(current_user)
       flash[:notice] = "You deleted #{@author.name}."
       redirect_to authors_path
     else

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -57,6 +57,19 @@ class AuthorsController < ApplicationController
     redirect_to author_path(@author)
   end
 
+  def destroy
+    @author = User.find(params[:id])
+
+    if current_user != @author
+      @author.destroy!
+      flash[:notice] = "You deleted #{@author.name}."
+      redirect_to authors_path
+    else
+      flash[:notice] = "You cannot delete yourself."
+      redirect_to author_path(@author)
+    end
+  end
+
   private
 
   def author_params

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -67,7 +67,7 @@ class AuthorsController < ApplicationController
       flash[:notice] = "You cannot delete yourself."
       redirect_to author_path(@author)
     else
-      replacement_author = User.find params[:replacement_author_id]
+      replacement_author = User.find(params[:replacement_author_id])
       @author.replace_and_destroy!(replacement_author)
       flash[:notice] = "You deleted #{@author.name} and re-assigned articles to #{replacement_author.name}."
       redirect_to authors_path

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -67,7 +67,7 @@ class AuthorsController < ApplicationController
       flash[:notice] = "You cannot delete yourself."
       redirect_to author_path(@author)
     else
-      replacement_author = current_user
+      replacement_author = User.find params[:replacement_author_id]
       @author.replace_and_destroy!(replacement_author)
       flash[:notice] = "You deleted #{@author.name} and re-assigned articles to #{replacement_author.name}."
       redirect_to authors_path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User < ApplicationRecord
   end
 
   def administrator?
-    ENV['ADMINISTRATORS'].split(':').include? id.to_s
+    ENV['ADMINISTRATORS'].split(',').include? id.to_s
   end
 
   def notify_about_stale_articles

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,10 +109,10 @@ class User < ApplicationRecord
   end
 
   def replace_with_user!(replacement)
-    articles.each    { |article| article.update! author: replacement }
+    articles.each { |article| article.update! author: replacement }
     articles.reload
 
-    edits.each       { |edit| edit.update! editor: replacement }
+    edits.each { |edit| edit.update! editor: replacement }
     edits.reload
 
     rot_reports.each { |rot_report| rot_report.update! rot_reporter: replacement }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,12 @@
 class User < ApplicationRecord
   belongs_to :article
-  has_many :articles, foreign_key: "author_id"
-  has_many :subscriptions, class_name: "ArticleSubscription"
+  has_many :articles, foreign_key: "author_id", dependent: :restrict_with_exception
+  has_many :subscriptions, class_name: "ArticleSubscription", dependent: :destroy
   has_many :subscribed_articles, through: :subscriptions, source: :article
-  has_many :endorsements, class_name: "ArticleEndorsement"
+  has_many :endorsements, class_name: "ArticleEndorsement", dependent: :destroy
   has_many :endorsed_articles, through: :endorsements, source: :article
-  has_many :edits, class_name: "Article", foreign_key: "editor_id"
+  has_many :edits, class_name: "Article", foreign_key: "editor_id", dependent: :restrict_with_exception
+  has_many :rot_reports, class_name: "Article", foreign_key: "rot_reporter_id", dependent: :restrict_with_exception
 
   store_accessor :preferences,
     :private_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,7 +94,10 @@ class User < ApplicationRecord
   end
 
   def replace_and_destroy!(other_user)
-    replace_with_user!(other_user) && destroy!
+    transaction do
+      replace_with_user!(other_user)
+      destroy!
+    end
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,6 +57,10 @@ class User < ApplicationRecord
     end
   end
 
+  def administrator?
+    ENV['ADMINISTRATORS'].split(':').include? id.to_s
+  end
+
   def notify_about_stale_articles
     return false unless self.active? # we don't want to send mailers to inactive authors
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,6 +89,10 @@ class User < ApplicationRecord
     self.name || self.email
   end
 
+  def replace_and_destroy!(other_user)
+    replace_with_user!(other_user) && destroy!
+  end
+
   private
   def self.email_whitelist_enabled?
     !!ENV['ORIENTATION_EMAIL_WHITELIST']
@@ -102,5 +106,18 @@ class User < ApplicationRecord
     if email_whitelist.none? { |rule| email.include?(rule) }
       errors.add(:email, "doesn't match the email domain whitelist: #{email_whitelist}")
     end
+  end
+
+  def replace_with_user!(replacement)
+    articles.each    { |article| article.update! author: replacement }
+    articles.reload
+
+    edits.each       { |edit| edit.update! editor: replacement }
+    edits.reload
+
+    rot_reports.each { |rot_report| rot_report.update! rot_reporter: replacement }
+    rot_reports.reload
+
+    self
   end
 end

--- a/app/views/authors/show.html.haml
+++ b/app/views/authors/show.html.haml
@@ -39,7 +39,7 @@
         .tac.mbm
           = link_to 'Toggle Status', author_toggle_status_path( @author ), method: :put
 
-        - unless @author == current_user
+        - if current_user.administrator? && @author != current_user
           .tac.mbm
             = link_to 'Delete Author', author_path( @author ), method: :delete, data: { confirm: 'Articles created, edited or marked as rot by this author will be re-assigned to you. Do you wish to continue?' }
 

--- a/app/views/authors/show.html.haml
+++ b/app/views/authors/show.html.haml
@@ -41,7 +41,11 @@
 
         - if current_user.administrator? && @author != current_user
           .tac.mbm
-            = link_to 'Delete Author', author_path( @author ), method: :delete, data: { confirm: 'Articles created, edited or marked as rot by this author will be re-assigned to you. Do you wish to continue?' }
+            .form.form--inline.mbm
+              = form_tag author_path( @author ), method: :delete, class: 'form' do
+                = label_tag 'replacement_author_id', 'Re-assign to new author & delete'
+                = select_tag 'replacement_author_id', options_from_collection_for_select( User.order(:name).all, 'id', 'name', current_user.id.to_s ), class: 'form-input'
+                = submit_tag 'Delete', class: '', data: { disable_with: 'Deleting...', confirm: "Articles created, edited or marked as rot by #{@author.name} will be re-assigned to the selected replacement author. Continue?" }
 
       .g-b.g-b--m--2of3
 

--- a/app/views/authors/show.html.haml
+++ b/app/views/authors/show.html.haml
@@ -38,6 +38,8 @@
 
         .tac.mbm
           = link_to 'Toggle Status', author_toggle_status_path( @author ), method: :put
+        .tac.mbm
+          = link_to 'Delete Author', author_path( @author ), method: :delete
 
       .g-b.g-b--m--2of3
 

--- a/app/views/authors/show.html.haml
+++ b/app/views/authors/show.html.haml
@@ -38,9 +38,10 @@
 
         .tac.mbm
           = link_to 'Toggle Status', author_toggle_status_path( @author ), method: :put
-          - unless @author == current_user
-            .tac.mbm
-              = link_to 'Delete Author', author_path( @author ), method: :delete, data: { confirm: 'Articles created, edited or marked as rot by this author will be re-assigned to you. Do you wish to continue?' }
+
+        - unless @author == current_user
+          .tac.mbm
+            = link_to 'Delete Author', author_path( @author ), method: :delete, data: { confirm: 'Articles created, edited or marked as rot by this author will be re-assigned to you. Do you wish to continue?' }
 
       .g-b.g-b--m--2of3
 

--- a/app/views/authors/show.html.haml
+++ b/app/views/authors/show.html.haml
@@ -38,8 +38,9 @@
 
         .tac.mbm
           = link_to 'Toggle Status', author_toggle_status_path( @author ), method: :put
-        .tac.mbm
-          = link_to 'Delete Author', author_path( @author ), method: :delete
+          - unless @author == current_user
+            .tac.mbm
+              = link_to 'Delete Author', author_path( @author ), method: :delete, data: { confirm: 'Articles created, edited or marked as rot by this author will be re-assigned to you. Do you wish to continue?' }
 
       .g-b.g-b--m--2of3
 

--- a/app/views/authors/show.html.haml
+++ b/app/views/authors/show.html.haml
@@ -87,4 +87,4 @@
                     and
                     = submit_tag "Delete Author",
                       class: 'btn btn--a btn--1',
-                      data: { disable_with: 'Deleting...', confirm: "Articles created, edited or marked as rot by #{@author.name} will be re-assigned to the selected replacement author. Continue?" }
+                      data: { disable_with: 'Deleting...', confirm: "Articles owned by #{author.name} will be re-assigned to selected user." }

--- a/app/views/authors/show.html.haml
+++ b/app/views/authors/show.html.haml
@@ -87,4 +87,4 @@
                     and
                     = submit_tag "Delete Author",
                       class: 'btn btn--a btn--1',
-                      data: { disable_with: 'Deleting...', confirm: "Articles owned by #{author.name} will be re-assigned to selected user." }
+                      data: { disable_with: 'Deleting...', confirm: "Articles owned by #{@author.name} will be re-assigned to selected user." }

--- a/app/views/authors/show.html.haml
+++ b/app/views/authors/show.html.haml
@@ -39,14 +39,6 @@
         .tac.mbm
           = link_to 'Toggle Status', author_toggle_status_path( @author ), method: :put
 
-        - if current_user.administrator? && @author != current_user
-          .tac.mbm
-            .form.form--inline.mbm
-              = form_tag author_path( @author ), method: :delete, class: 'form' do
-                = label_tag 'replacement_author_id', 'Re-assign to new author & delete'
-                = select_tag 'replacement_author_id', options_from_collection_for_select( User.order(:name).all, 'id', 'name', current_user.id.to_s ), class: 'form-input'
-                = submit_tag 'Delete', class: '', data: { disable_with: 'Deleting...', confirm: "Articles created, edited or marked as rot by #{@author.name} will be re-assigned to the selected replacement author. Continue?" }
-
       .g-b.g-b--m--2of3
 
         %h2.mbs Created Articles
@@ -75,9 +67,24 @@
 
         %h2.mbs Article Subscriptions
         - if @author.subscribed_articles.count > 0
-          %ul.list.list--xs
+          %ul.list.list--xs.mbl
             - @author.subscribed_articles.each do | article |
               %li.card.list-item.article{ class: ( 'has-article-footer' if article.tags.any? ) }
                 = link_to article.title, article, class: 'article-title'
         - else
           %p #{ @author.first_name } isn't subscribed to any articles yet.
+
+        - if current_user.administrator? && @author != current_user
+          %h2.mbs Danger Zone
+
+          .form
+            = form_tag author_path( @author ), method: :delete, class: 'form' do
+              .form-field
+                = label_tag :replacement_author_id do
+                  %span.form-label.label
+                    Re-assign articles to
+                    = select_tag 'replacement_author_id', options_from_collection_for_select( User.active.order(:name), 'id', 'name', current_user.id )
+                    and
+                    = submit_tag "Delete Author",
+                      class: 'btn btn--a btn--1',
+                      data: { disable_with: 'Deleting...', confirm: "Articles created, edited or marked as rot by #{@author.name} will be re-assigned to the selected replacement author. Continue?" }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   resources :tags
 
-  resources :authors, only: [:index, :show, :new, :create, :update] do
+  resources :authors, only: [:index, :show, :new, :create, :update, :destroy] do
     put :toggle_status, to: "authors#toggle_status", as: "toggle_status"
     put :toggle_email_privacy
   end

--- a/spec/features/deleting_an_author_spec.rb
+++ b/spec/features/deleting_an_author_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'deleting an author' do
           expect do
             expect do
               select logged_in_user.name, from: 'replacement_author_id'
-              click_link_or_button 'Delete'
+              click_link_or_button 'Delete Author'
               expect(current_path).to eq(authors_path)
             end.to change { article.reload.author }.from(author).to(logged_in_user)
           end.to change { edit.reload.editor }.from(author).to(logged_in_user)

--- a/spec/features/deleting_an_author_spec.rb
+++ b/spec/features/deleting_an_author_spec.rb
@@ -4,21 +4,33 @@ RSpec.describe 'deleting an author' do
   let!(:logged_in_user) { create(:user) }
   let(:author) { create(:user) }
 
-  it "should redirect to authors index" do
-    visit author_path(author.id)
+  it "forbids non administrators to delete users" do
+    with_modified_env(ADMINISTRATORS: "#{logged_in_user.id + 1}") do
+      visit author_path(author.id)
 
-    expect do
-      click_link_or_button 'Delete Author'
-      expect(current_path).to eq(authors_path)
-    end.to change { User.where(id: author.id).count }.from(1).to(0)
+      expect { click_link_or_button 'Delete Author' }
+        .to raise_error(Capybara::ElementNotFound)
+    end
+  end
+
+  it "should redirect to authors index" do
+    with_modified_env(ADMINISTRATORS: "42:#{logged_in_user.id}:10101") do
+      visit author_path(author.id)
+
+      expect do
+        click_link_or_button 'Delete Author'
+        expect(current_path).to eq(authors_path)
+      end.to change { User.where(id: author.id).count }.from(1).to(0)
+    end
   end
 
   it "should not delete itself" do
-    visit author_path(logged_in_user.id)
+    with_modified_env(ADMINISTRATORS: "42:#{logged_in_user.id}:10101") do
+      visit author_path(logged_in_user.id)
 
-    expect do
-      click_link_or_button 'Delete Author'
-    end.to raise_error(Capybara::ElementNotFound)
+      expect { click_link_or_button 'Delete Author' }
+        .to raise_error(Capybara::ElementNotFound)
+    end
   end
 
   context 'author with articles, edits and rot reports' do
@@ -27,16 +39,18 @@ RSpec.describe 'deleting an author' do
     let(:rot_report) { create(:article, rot_reporter: author) }
 
     it "should re-assign the author to be logged in user" do
-      visit author_path(author.id)
+      with_modified_env(ADMINISTRATORS: "42:#{logged_in_user.id}:10101") do
+        visit author_path(author.id)
 
-      expect do
         expect do
           expect do
-            click_link_or_button 'Delete Author'
-            expect(current_path).to eq(authors_path)
-          end.to change { article.reload.author }.from(author).to(logged_in_user)
-        end.to change { edit.reload.editor }.from(author).to(logged_in_user)
-      end.to change { rot_report.reload.rot_reporter }.from(author).to(logged_in_user)
+            expect do
+              click_link_or_button 'Delete Author'
+              expect(current_path).to eq(authors_path)
+            end.to change { article.reload.author }.from(author).to(logged_in_user)
+          end.to change { edit.reload.editor }.from(author).to(logged_in_user)
+        end.to change { rot_report.reload.rot_reporter }.from(author).to(logged_in_user)
+      end
     end
   end
 end

--- a/spec/features/deleting_an_author_spec.rb
+++ b/spec/features/deleting_an_author_spec.rb
@@ -27,18 +27,38 @@ RSpec.describe 'deleting an author' do
     let(:edit) { create(:article, editor: author) }
     let(:rot_report) { create(:article, rot_reporter: author) }
 
-    it "re-assigns the author to be logged in user" do
+    it "re-assigns articles to a new user" do
       with_modified_env(ADMINISTRATORS: "42,#{logged_in_user.id},10101") do
         visit author_path(author.id)
 
         expect do
-          expect do
-            expect do
-              select logged_in_user.name, from: 'replacement_author_id', wait: 3
-              click_link_or_button 'Delete Author'
-              expect(current_path).to eq(authors_path)
-            end.to change { article.reload.author }.from(author).to(logged_in_user)
-          end.to change { edit.reload.editor }.from(author).to(logged_in_user)
+          select logged_in_user.name, from: 'replacement_author_id', wait: 3
+          click_link_or_button 'Delete Author'
+          expect(current_path).to eq(authors_path)
+        end.to change { article.reload.author }.from(author).to(logged_in_user)
+      end
+    end
+
+    it "re-assigns edits to a new user" do
+      with_modified_env(ADMINISTRATORS: "42,#{logged_in_user.id},10101") do
+        visit author_path(author.id)
+
+        expect do
+          select logged_in_user.name, from: 'replacement_author_id', wait: 3
+          click_link_or_button 'Delete Author'
+          expect(current_path).to eq(authors_path)
+        end.to change { edit.reload.editor }.from(author).to(logged_in_user)
+      end
+    end
+
+    it "re-assigns rot reports to a new user" do
+      with_modified_env(ADMINISTRATORS: "42,#{logged_in_user.id},10101") do
+        visit author_path(author.id)
+
+        expect do
+          select logged_in_user.name, from: 'replacement_author_id', wait: 3
+          click_link_or_button 'Delete Author'
+          expect(current_path).to eq(authors_path)
         end.to change { rot_report.reload.rot_reporter }.from(author).to(logged_in_user)
       end
     end

--- a/spec/features/deleting_an_author_spec.rb
+++ b/spec/features/deleting_an_author_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'deleting an author' do
     end
   end
 
-  it "should redirect to authors index" do
+  it "redirects to authors index" do
     with_modified_env(ADMINISTRATORS: "42:#{logged_in_user.id}:10101") do
       visit author_path(author.id)
 
@@ -24,7 +24,7 @@ RSpec.describe 'deleting an author' do
     end
   end
 
-  it "should not delete itself" do
+  it "does not delete itself" do
     with_modified_env(ADMINISTRATORS: "42:#{logged_in_user.id}:10101") do
       visit author_path(logged_in_user.id)
 
@@ -38,7 +38,7 @@ RSpec.describe 'deleting an author' do
     let(:edit) { create(:article, editor: author) }
     let(:rot_report) { create(:article, rot_reporter: author) }
 
-    it "should re-assign the author to be logged in user" do
+    it "re-assigns the author to be logged in user" do
       with_modified_env(ADMINISTRATORS: "42:#{logged_in_user.id}:10101") do
         visit author_path(author.id)
 

--- a/spec/features/deleting_an_author_spec.rb
+++ b/spec/features/deleting_an_author_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe 'deleting an author' do
 
     expect do
       click_link_or_button 'Delete Author'
-      expect(current_path).to eq(author_path(logged_in_user.id))
-    end.not_to change { User.where(id: author.id).count }
+    end.to raise_error(Capybara::ElementNotFound)
   end
 end

--- a/spec/features/deleting_an_author_spec.rb
+++ b/spec/features/deleting_an_author_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'deleting an author' do
   end
 
   it "does not delete itself" do
-    with_modified_env(ADMINISTRATORS: "42:#{logged_in_user.id}:10101") do
+    with_modified_env(ADMINISTRATORS: "42,#{logged_in_user.id},10101") do
       visit author_path(logged_in_user.id)
 
       expect { click_link_or_button 'Delete Author' }
@@ -28,7 +28,7 @@ RSpec.describe 'deleting an author' do
     let(:rot_report) { create(:article, rot_reporter: author) }
 
     it "re-assigns the author to be logged in user" do
-      with_modified_env(ADMINISTRATORS: "42:#{logged_in_user.id}:10101") do
+      with_modified_env(ADMINISTRATORS: "42,#{logged_in_user.id},10101") do
         visit author_path(author.id)
 
         expect do

--- a/spec/features/deleting_an_author_spec.rb
+++ b/spec/features/deleting_an_author_spec.rb
@@ -13,17 +13,6 @@ RSpec.describe 'deleting an author' do
     end
   end
 
-  it "redirects to authors index" do
-    with_modified_env(ADMINISTRATORS: "42:#{logged_in_user.id}:10101") do
-      visit author_path(author.id)
-
-      expect do
-        click_link_or_button 'Delete Author'
-        expect(current_path).to eq(authors_path)
-      end.to change { User.where(id: author.id).count }.from(1).to(0)
-    end
-  end
-
   it "does not delete itself" do
     with_modified_env(ADMINISTRATORS: "42:#{logged_in_user.id}:10101") do
       visit author_path(logged_in_user.id)
@@ -45,7 +34,8 @@ RSpec.describe 'deleting an author' do
         expect do
           expect do
             expect do
-              click_link_or_button 'Delete Author'
+              select logged_in_user.name, from: 'replacement_author_id'
+              click_link_or_button 'Delete'
               expect(current_path).to eq(authors_path)
             end.to change { article.reload.author }.from(author).to(logged_in_user)
           end.to change { edit.reload.editor }.from(author).to(logged_in_user)

--- a/spec/features/deleting_an_author_spec.rb
+++ b/spec/features/deleting_an_author_spec.rb
@@ -20,4 +20,23 @@ RSpec.describe 'deleting an author' do
       click_link_or_button 'Delete Author'
     end.to raise_error(Capybara::ElementNotFound)
   end
+
+  context 'author with articles, edits and rot reports' do
+    let(:article) { create(:article, author: author) }
+    let(:edit) { create(:article, editor: author) }
+    let(:rot_report) { create(:article, rot_reporter: author) }
+
+    it "should re-assign the author to be logged in user" do
+      visit author_path(author.id)
+
+      expect do
+        expect do
+          expect do
+            click_link_or_button 'Delete Author'
+            expect(current_path).to eq(authors_path)
+          end.to change { article.reload.author }.from(author).to(logged_in_user)
+        end.to change { edit.reload.editor }.from(author).to(logged_in_user)
+      end.to change { rot_report.reload.rot_reporter }.from(author).to(logged_in_user)
+    end
+  end
 end

--- a/spec/features/deleting_an_author_spec.rb
+++ b/spec/features/deleting_an_author_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe 'deleting an author' do
+  let!(:logged_in_user) { create(:user) }
+  let(:author) { create(:user) }
+
+  it "should redirect to authors index" do
+    visit author_path(author.id)
+
+    expect do
+      click_link_or_button 'Delete Author'
+      expect(current_path).to eq(authors_path)
+    end.to change { User.where(id: author.id).count }.from(1).to(0)
+  end
+
+  it "should not delete itself" do
+    visit author_path(logged_in_user.id)
+
+    expect do
+      click_link_or_button 'Delete Author'
+      expect(current_path).to eq(author_path(logged_in_user.id))
+    end.not_to change { User.where(id: author.id).count }
+  end
+end

--- a/spec/features/deleting_an_author_spec.rb
+++ b/spec/features/deleting_an_author_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'deleting an author' do
         expect do
           expect do
             expect do
-              select logged_in_user.name, from: 'replacement_author_id'
+              select logged_in_user.name, from: 'replacement_author_id', wait: 3
               click_link_or_button 'Delete Author'
               expect(current_path).to eq(authors_path)
             end.to change { article.reload.author }.from(author).to(logged_in_user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -112,15 +112,15 @@ RSpec.describe User do
 
     context 'with endorsements' do
       let(:article_for_endorsement) { create(:article) }
-      let(:article_endorsemet) { create(:article_endorsement, user: user, article: article_for_endorsement) }
+      let(:article_endorsement) { create(:article_endorsement, user: user, article: article_for_endorsement) }
 
       it 'removes endorsements without removing articles' do
-        expect(article_endorsemet).to be_truthy
+        expect(article_endorsement).to be_truthy
 
         expect(user.destroy).to be_truthy
 
         expect(article_for_endorsement).to be_truthy
-        expect { article_endorsemet.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { article_endorsement.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -138,4 +138,22 @@ RSpec.describe User do
       end
     end
   end
+
+  context "#replace_and_destroy!" do
+    let(:user) { create(:user) }
+    let(:replacement) { create(:user) }
+    let(:article) { create(:article, author: user) }
+    let(:edit) { create(:article, editor: user) }
+    let(:rot_report) { create(:article, rot_reporter: user) }
+
+    it 'replaces with another user and destroys' do
+      expect do
+        expect do
+          expect do
+            expect(user.replace_and_destroy!(replacement)).to eq user
+          end.to change { article.reload.author }.from(user).to(replacement)
+        end.to change { edit.reload.editor }.from(user).to(replacement)
+      end.to change { rot_report.reload.rot_reporter }.from(user).to(replacement)
+    end
+  end
 end


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/126530671

Added ability to re-assign articles to new author & delete author.

# QA instructions

 1. Go to our staging environment.
 1. Click on Authors.
 1. Select an author with at least 1 contribution.
 1. You should see "Danger Zone" in the bottom of the page.
 1. Choose another user and delete the current author.
 1. New author should get all contributions (articles created, edited and marked as rot) from deleted author.

# Technical details

It's in the bottom of the Author's page, called "Danger Zone" (GitHub inspired). This section is only visible to administrators, which are specified in the .env file (didn't want to add a whole new permission system to Orientation just for that, but also didn't want to allow anyone to delete authors).

<img width="1019" alt="orientation" src="https://cloud.githubusercontent.com/assets/3586/19282004/e155e2ba-8fc2-11e6-9b57-e8abdd5d830e.png">

Confirmation prompt after clicking the DELETE AUTHOR button:

<img width="429" alt="orientation" src="https://cloud.githubusercontent.com/assets/3586/19283970/601b0c54-8fca-11e6-85e1-ababefafa9e1.png">

P.S.: due to pending PR #37, I am comparing this with `official_sync` branch for now, will change that to `pseudo-master` before merging.
