### PR TITLE
rot_reporter link should link to rot reporter, not author

### DIFF
--- a/app/decorators/article_decorator.rb
+++ b/app/decorators/article_decorator.rb
@@ -51,7 +51,7 @@ class ArticleDecorator < ApplicationDecorator
 
   def rot_reporter
     if object.rot_reporter
-      link_to AuthorDecorator.new(object.rot_reporter), author_url(object.author)
+      link_to AuthorDecorator.new(object.rot_reporter), author_url(object.rot_reporter)
     end
   end
 


### PR DESCRIPTION
PR: https://www.pivotaltracker.com/story/show/132126693

Simple bug, fixed.