### PR TITLE
[#133962679] Use string to compare env variables rather than symbol

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,4 +1,4 @@
-if Rails.configuration.orientation["exception_reporter"] == :bugsnag
+if Rails.configuration.orientation["exception_reporter"] == "bugsnag"
   require "bugsnag"
 
   Bugsnag.configure do |config|


### PR DESCRIPTION
This configuration variable comes from an environment variable.  Since environment variables are strings, they can't be directly compared to symbols.  This PR changes the right-hand side to a string so it can be directly compared to the configuration value.

** I'm still trying to get my specs passing, but it doesn't look like this change causes any additional specs to fail.  I also don't think writing specs for this would provide value proportional to the effort to write the specs.

Please review @DanielNill @AhmedBelal @maletor Thanks!!