### PR TITLE
[#133962679] Update bugsnag, move to production group and require

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ gem 'pg_search', github: 'Casecommons/pg_search'
 gem 'activemodel-serializers-xml', github: 'rails/activemodel-serializers-xml'
 gem 'draper', github: 'audionerd/draper', branch: 'rails5'
 gem 'responders','~> 2.0'
-gem 'bugsnag', require: false
 gem 'slack-notifier'
 gem 'friendly_id', github: "norman/friendly_id", branch: "master"
 gem 'dotenv-rails'
@@ -78,4 +77,8 @@ group :production, :staging do
   gem 'rack-timeout'
   gem 'unicorn'
   gem 'skylight'
+end
+
+group :production do
+  gem 'bugsnag'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bugsnag (4.0.2)
+    bugsnag (5.0.1)
     builder (3.2.2)
     bullet (5.0.0)
       activesupport (>= 3.0.0)
@@ -431,4 +431,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.2
+   1.13.6

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,6 +1,4 @@
 if Rails.configuration.orientation["exception_reporter"] == "bugsnag"
-  require "bugsnag"
-
   Bugsnag.configure do |config|
     # the API key is set with the BUGSNAG_API_KEY environment variable but you
     # can also hardcode it here with the following configuration variable:


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1584647/stories/133962679

Delaying requiring `bugsnag` until the initializer was causing problems:

```
NoMethodError: undefined method `configure' for Bugsnag:Module
	from /app/vendor/bundle/ruby/2.3.0/gems/bugsnag-4.0.2/lib/bugsnag/railtie.rb:30:in `block in <class:Railtie>'
```

I haven't been able to determine what the actual issue is, but was able to recreate it locally and work around it with this change.  For this project, it seems reasonable to restrict error reporting to the `production` environment.