### PR TITLE
Add require_dependency for module under /lib

### DIFF
--- a/app/mailers/article_mailer.rb
+++ b/app/mailers/article_mailer.rb
@@ -6,6 +6,8 @@
 # This email can be tested using the `.test` method:
 #   ArticleMailer.test(:notify_author_of_staleness, email: <author.email>)
 #
+require_dependency 'html_diff_tool'
+
 class ArticleMailer < ActionMailer::Base
   include ActionView::Helpers::UrlHelper
   include ApplicationHelper
@@ -75,7 +77,7 @@ class ArticleMailer < ActionMailer::Base
                   }
   end
 
-  private
+  # private
 
   # Orientation is meant to be used with mandril and this is a simple adapter to
   # ensure we keep the code above unchanged to avoid potential merge headaches
@@ -123,7 +125,6 @@ class ArticleMailer < ActionMailer::Base
 
   def formatted_changes(last_value, article_value)
     if last_value != article_value
-      require_dependency "#{File.join(Rails.root, "lib", "html_diff_tool")}"
       HTMLDiffTool.diff(last_value, article_value)
     else
       ''

--- a/app/mailers/article_mailer.rb
+++ b/app/mailers/article_mailer.rb
@@ -77,7 +77,7 @@ class ArticleMailer < ActionMailer::Base
                   }
   end
 
-  # private
+  private
 
   # Orientation is meant to be used with mandril and this is a simple adapter to
   # ensure we keep the code above unchanged to avoid potential merge headaches

--- a/app/mailers/article_mailer.rb
+++ b/app/mailers/article_mailer.rb
@@ -123,6 +123,7 @@ class ArticleMailer < ActionMailer::Base
 
   def formatted_changes(last_value, article_value)
     if last_value != article_value
+      require_dependency "#{File.join(Rails.root, "lib", "html_diff_tool")}"
       HTMLDiffTool.diff(last_value, article_value)
     else
       ''

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,5 +48,7 @@ module Orientation
     #   Rails.configuration.orientation["transactional_mailer"]
     #
     config.orientation = config_for(:orientation)
+
+    config.autoload_paths << "#{Rails.root}/lib"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,7 +48,5 @@ module Orientation
     #   Rails.configuration.orientation["transactional_mailer"]
     #
     config.orientation = config_for(:orientation)
-
-    config.autoload_paths << "#{Rails.root}/lib"
   end
 end


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/140893151
Fix uninitialized constant ArticleMailer::HTMLDiffTool error.

According to the Rails 5 guides: Lib was in the list years ago, but no longer is. so it is added. 