### PR TITLE
Added foreign_key to endorsement and subscription

### DIFF
--- a/db/migrate/20170308184000_add_endorsement_ref_to_article.rb
+++ b/db/migrate/20170308184000_add_endorsement_ref_to_article.rb
@@ -1,0 +1,5 @@
+class AddEndorsementRefToArticle < ActiveRecord::Migration[5.0]
+  def change
+  	add_foreign_key :article_endorsements, :articles
+  end
+end

--- a/db/migrate/20170308184021_add_subscription_ref_to_article.rb
+++ b/db/migrate/20170308184021_add_subscription_ref_to_article.rb
@@ -1,0 +1,5 @@
+class AddSubscriptionRefToArticle < ActiveRecord::Migration[5.0]
+  def change
+  	add_foreign_key :article_subscriptions, :articles
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,11 +2,12 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.4
--- Dumped by pg_dump version 9.5.4
+-- Dumped from database version 9.6.2
+-- Dumped by pg_dump version 9.6.2
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
@@ -138,6 +139,39 @@ ALTER SEQUENCE article_subscriptions_id_seq OWNED BY article_subscriptions.id;
 
 
 --
+-- Name: article_views; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE article_views (
+    id integer NOT NULL,
+    article_id integer NOT NULL,
+    user_id integer NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    count integer DEFAULT 1
+);
+
+
+--
+-- Name: article_views_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE article_views_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: article_views_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE article_views_id_seq OWNED BY article_views.id;
+
+
+--
 -- Name: articles; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -158,8 +192,7 @@ CREATE TABLE articles (
     subscriptions_count integer DEFAULT 0,
     endorsements_count integer DEFAULT 0,
     visits integer DEFAULT 0 NOT NULL,
-    rot_reporter_id integer,
-    change_last_communicated_at timestamp without time zone
+    rot_reporter_id integer
 );
 
 
@@ -187,9 +220,9 @@ ALTER SEQUENCE articles_id_seq OWNED BY articles.id;
 --
 
 CREATE TABLE articles_tags (
+    id integer NOT NULL,
     article_id integer,
-    tag_id integer,
-    id integer NOT NULL
+    tag_id integer
 );
 
 
@@ -473,84 +506,91 @@ ALTER SEQUENCE versions_id_seq OWNED BY versions.id;
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: article_endorsements id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY article_endorsements ALTER COLUMN id SET DEFAULT nextval('article_endorsements_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: article_subscriptions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY article_subscriptions ALTER COLUMN id SET DEFAULT nextval('article_subscriptions_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: article_views id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY article_views ALTER COLUMN id SET DEFAULT nextval('article_views_id_seq'::regclass);
+
+
+--
+-- Name: articles id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY articles ALTER COLUMN id SET DEFAULT nextval('articles_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: articles_tags id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY articles_tags ALTER COLUMN id SET DEFAULT nextval('articles_tags_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: attachinary_files id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY attachinary_files ALTER COLUMN id SET DEFAULT nextval('attachinary_files_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: delayed_jobs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY delayed_jobs ALTER COLUMN id SET DEFAULT nextval('delayed_jobs_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: friendly_id_slugs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY friendly_id_slugs ALTER COLUMN id SET DEFAULT nextval('friendly_id_slugs_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: tags id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tags ALTER COLUMN id SET DEFAULT nextval('tags_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: update_requests id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY update_requests ALTER COLUMN id SET DEFAULT nextval('update_requests_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: versions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY versions ALTER COLUMN id SET DEFAULT nextval('versions_id_seq'::regclass);
 
 
 --
--- Name: ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY ar_internal_metadata
@@ -558,7 +598,7 @@ ALTER TABLE ONLY ar_internal_metadata
 
 
 --
--- Name: article_endorsements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: article_endorsements article_endorsements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY article_endorsements
@@ -566,7 +606,7 @@ ALTER TABLE ONLY article_endorsements
 
 
 --
--- Name: article_subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: article_subscriptions article_subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY article_subscriptions
@@ -574,7 +614,15 @@ ALTER TABLE ONLY article_subscriptions
 
 
 --
--- Name: articles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: article_views article_views_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY article_views
+    ADD CONSTRAINT article_views_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: articles articles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY articles
@@ -582,7 +630,7 @@ ALTER TABLE ONLY articles
 
 
 --
--- Name: articles_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: articles_tags articles_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY articles_tags
@@ -590,7 +638,7 @@ ALTER TABLE ONLY articles_tags
 
 
 --
--- Name: attachinary_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: attachinary_files attachinary_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY attachinary_files
@@ -598,7 +646,7 @@ ALTER TABLE ONLY attachinary_files
 
 
 --
--- Name: delayed_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: delayed_jobs delayed_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY delayed_jobs
@@ -606,7 +654,7 @@ ALTER TABLE ONLY delayed_jobs
 
 
 --
--- Name: friendly_id_slugs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: friendly_id_slugs friendly_id_slugs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY friendly_id_slugs
@@ -614,7 +662,7 @@ ALTER TABLE ONLY friendly_id_slugs
 
 
 --
--- Name: tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: tags tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tags
@@ -622,7 +670,7 @@ ALTER TABLE ONLY tags
 
 
 --
--- Name: update_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: update_requests update_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY update_requests
@@ -630,7 +678,7 @@ ALTER TABLE ONLY update_requests
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users
@@ -638,7 +686,7 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: versions versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY versions
@@ -671,6 +719,27 @@ CREATE INDEX by_scoped_parent ON attachinary_files USING btree (attachinariable_
 --
 
 CREATE INDEX delayed_jobs_priority ON delayed_jobs USING btree (priority, run_at);
+
+
+--
+-- Name: index_article_views_on_article_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_article_views_on_article_id ON article_views USING btree (article_id);
+
+
+--
+-- Name: index_article_views_on_article_id_and_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_article_views_on_article_id_and_user_id ON article_views USING btree (article_id, user_id);
+
+
+--
+-- Name: index_article_views_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_article_views_on_user_id ON article_views USING btree (user_id);
 
 
 --
@@ -751,11 +820,27 @@ CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (v
 
 
 --
+-- Name: article_subscriptions fk_rails_a02cfe7c2a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY article_subscriptions
+    ADD CONSTRAINT fk_rails_a02cfe7c2a FOREIGN KEY (article_id) REFERENCES articles(id);
+
+
+--
+-- Name: article_endorsements fk_rails_d3f9d85708; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY article_endorsements
+    ADD CONSTRAINT fk_rails_d3f9d85708 FOREIGN KEY (article_id) REFERENCES articles(id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
 SET search_path TO "$user", public;
 
-INSERT INTO schema_migrations (version) VALUES ('20121012052227'), ('20121012053216'), ('20121024172653'), ('20121101215757'), ('20121101230245'), ('20121107203955'), ('20121107205723'), ('20121228090236'), ('20130218024132'), ('20130224191645'), ('20130302074219'), ('20130519172832'), ('20131002145513'), ('20131003155044'), ('20140215004410'), ('20140216160144'), ('20140217025247'), ('20140522210252'), ('20140602153320'), ('20140606204236'), ('20140923231243'), ('20141111222212'), ('20150117041549'), ('20150129150300'), ('20150328040718'), ('20150328040918'), ('20150328074815'), ('20150416104151'), ('20150829203748'), ('20150901204841'), ('20150921154734'), ('20150922194413'), ('20150922233803'), ('20160220002317'), ('20160220002318'), ('20160222234001'), ('20160710170239'), ('20161028171951'), ('20161108170423');
+INSERT INTO schema_migrations (version) VALUES ('20121012052227'), ('20121012053216'), ('20121024172653'), ('20121101215757'), ('20121101230245'), ('20121107203955'), ('20121107205723'), ('20121228090236'), ('20130218024132'), ('20130224191645'), ('20130302074219'), ('20130519172832'), ('20131002145513'), ('20131003155044'), ('20140215004410'), ('20140216160144'), ('20140217025247'), ('20140522210252'), ('20140602153320'), ('20140606204236'), ('20140923231243'), ('20141111222212'), ('20150117041549'), ('20150129150300'), ('20150328040718'), ('20150328040918'), ('20150328074815'), ('20150416104151'), ('20150829203748'), ('20150901204841'), ('20150921154734'), ('20150922194413'), ('20150922233803'), ('20160220002317'), ('20160220002318'), ('20160222234001'), ('20160710170239'), ('20161028171951'), ('20161108170423'), ('20170205101633'), ('20170205222526'), ('20170308184000'), ('20170308184021');
 
 


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/133967733

This guarantees referential integrity on db so prevents article_endorsement and article_subscription exist without proper reference to an article.

QA: 
1. Add new article and click subscription and endorsement
2. Delete the article and the subscription and endorsement also destroyed 