### PR TITLE
Added filterable 'tags' for algoliasearch Article model, and added client-side filtering of algoliasearch models.

### DIFF
--- a/app/assets/javascripts/components/searchUtils.coffee
+++ b/app/assets/javascripts/components/searchUtils.coffee
@@ -1,0 +1,24 @@
+# *************************************
+#
+#   Search Utils
+#   -> Helper functions for algolia-
+#      search autocomplete
+#
+# *************************************
+
+# Returns JSON object denoting filter for client-side algoliasarch autocomplete
+@Orientation.matchFilter = ( title ) ->
+  filter = title.split(' ')[0].toLowerCase() || ''
+
+  if filter is 'fresh' or filter is 'stale' or filter is 'outdated' or
+     filter is 'archived'
+    { tagFilters: filter }
+  else
+    {}
+
+
+# Merges two JSON objects to resulting 'search_options' object for use with
+# algoliasearch autocomplete
+@Orientation.searchOptions = () ->
+  filter = Orientation.matchFilter(document.title)
+  $.extend({ hitsPerPage: 5 }, filter)

--- a/app/assets/javascripts/domready.coffee.erb
+++ b/app/assets/javascripts/domready.coffee.erb
@@ -36,10 +36,12 @@ jQuery ($) ->
     preventDuplicates: true
 
   if (typeof autocomplete != 'undefined')
-    algoliaAppId = '<%= ENV.fetch("ALGOLIA_APP_ID") %>';
-    algoliaSearchOnlyApiKey = '<%= ENV.fetch("ALGOLIA_SEARCH_ONLY_API_KEY") %>';
-    client = algoliasearch(algoliaAppId, algoliaSearchOnlyApiKey);
-    index = client.initIndex('Article');
+    algoliaAppId = '<%= ENV.fetch("ALGOLIA_APP_ID") %>'
+    algoliaSearchOnlyApiKey = '<%= ENV.fetch("ALGOLIA_SEARCH_ONLY_API_KEY") %>'
+
+    client = algoliasearch(algoliaAppId, algoliaSearchOnlyApiKey)
+    index = client.initIndex('Article')
+
     autocomplete_suggestion_template = {
       suggestion: (hit) ->
         return '<div class="search-result-title">' +
@@ -50,7 +52,7 @@ jQuery ($) ->
 
     ac = autocomplete('#search', { hint: true }, [
       {
-        source: autocomplete.sources.hits(index, { hitsPerPage: 5 }),
+        source: autocomplete.sources.hits(index, Orientation.searchOptions()),
         displayKey: 'title',
         templates: autocomplete_suggestion_template
       }

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -25,6 +25,8 @@ class Article < ApplicationRecord
       tags.map { |t| { name: t.name } }
     end
 
+    tags { %w[fresh stale outdated archived].select { |tag| send("#{tag}?") } }
+
     searchableAttributes %w[title tags content]
     ranking ['asc(title)', 'exact', 'attribute', 'proximity']
   end


### PR DESCRIPTION
# Overview
- Uses algoliasearch on all views with the `app/views/articles/_search.haml` partial
- Algoliasearch autocomplete is now filterable for article types

___

### What changed?

- Uses algoliasearch for all controller methods which `render :index`, not just the `index` method
  - The `app/views/articles/index.js.erb` page wasn’t being loaded for the views corresponding to the `fresh`, `stale`, `outdated`, `archived`, `popular`, or `search` controller methods - which is why the wiki wasn't refreshing the search results on form submit

___

- The filtering of the articles is now done both client-side and server-side.
  - Algoliasearch autocomplete would fetch all articles, rather than filtering based on the server-side filter