### PR TITLE
Restrict non-admin users from creating/updating/deleting categories.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :current_user
 
+  def admin_user?
+    current_user.administrator?
+  end
+  helper_method :admin_user?
+
   def user_signed_in?
     current_user.present?
   end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -7,6 +7,7 @@ class CategoriesController < ApplicationController
   before_action :set_articles, only: [:index, :show]
   before_action :set_categories, only: [:index, :show]
   before_action :set_category, only: [:show, :edit, :update, :destroy]
+  before_action :redirect_unless_admin_user, only: [:new, :create, :edit, :update, :destroy]
 
   # GET /categories
   def index
@@ -98,5 +99,13 @@ class CategoriesController < ApplicationController
     results = search_results.collect { |a| scope.where(title: a["title"])[0] }.compact
 
     ArticleDecorator.decorate_collection(results, context: { search_params: params[:search] })
+  end
+
+  def redirect_unless_admin_user
+    return if admin_user?
+    flash[:notice] = "You must be an admin user to perform this action."
+    redirect_to(:back)
+  rescue ActionController::RedirectBackError
+    redirect_to root_path
   end
 end

--- a/app/views/categories/_categories.haml
+++ b/app/views/categories/_categories.haml
@@ -10,4 +10,5 @@
             .guide-content
               %h2.guide-title= category.label
 
-= link_to 'Add Department', new_category_path
+- if admin_user?
+  = link_to 'Add Department', new_category_path

--- a/app/views/categories/show.haml
+++ b/app/views/categories/show.haml
@@ -6,5 +6,7 @@
 %section.row
   .cell.well.well--l
     = render 'categories/articles', articles: @category_articles
-    = link_to 'Edit Department', edit_category_url( @category ), class: 'btn btn--a',
-      data: { shortcut: 'e' }
+
+    - if admin_user?
+      = link_to 'Edit Department', edit_category_url( @category ), class: 'btn btn--a',
+        data: { shortcut: 'e' }


### PR DESCRIPTION
## Todo:
- [x] Update view to only show admin users 'edit', 'update', 'delete' buttons, etc.
- [x] Test / write specs