### PR TITLE
Added ArticleParserService to abstract article parsing logic away from redcarpet markdown parser.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,7 +47,6 @@ module ApplicationHelper
 
   def configure_markdown_parser(options)
     markdown_parser.renderer.options = options
-    markdown_parser.renderer.permalinks = []
   end
 
   def markdown_parser

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -78,6 +78,7 @@ class Article < ApplicationRecord
 
   has_many :articles_tags, dependent: :destroy
   has_many :articles_categories, dependent: :destroy
+  has_many :broken_links, dependent: :destroy
   has_many :update_requests, dependent: :destroy
   has_many :tags, through: :articles_tags, counter_cache: :tags_count
   has_many :categories, through: :articles_categories

--- a/app/services/article_parser_service.rb
+++ b/app/services/article_parser_service.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+#
+# ArticleParserService.rb
+# Helpers service for parsing articles in html_with_pygments.rb
+#
+class ArticleParserService
+  attr_reader :full_document, :options, :permalinks, :external_permalinks, :broken_link_factory
+  def initialize(options, full_document)
+    @full_document       = full_document
+    @options             = options
+    @permalinks          = anchor_tags_current_page
+    @external_permalinks = anchor_tags_external_pages || {}
+    @broken_link_factory = BrokenLinksFactory.new
+  end
+
+  def article_link_status(link)
+    return if valid_article?(link)
+    broken_link_factory.build(link_params(link)) if build_links?
+    "article-not-found"
+  end
+
+  def internal_link?(link)
+    url = safe_url_parser(link)
+    return false if url.blank?
+
+    if url.absolute?
+      root = Rails.application.routes.url_helpers.root_url(host: ENV.fetch("ORIENTATION_DOMAIN"))
+      link.include?(root)
+    else
+      true
+    end
+  end
+
+  def valid_article?(link)
+    return true if anchor_tag?(link) || valid_external_anchor_tag?(link)
+
+    url = safe_url_parser(link)
+    return false if url.blank?
+
+    link = url.path unless internal_link?(link)
+    return false if link.nil?
+
+    slug = link.split("/").last
+    Article.friendly.find(slug)
+  rescue ActiveRecord::RecordNotFound
+    false
+  end
+
+  private
+
+  # Match all anchor tags on an external link page
+  #   @returns: hash mapping external url to value of its validity
+  def anchor_tags_external_pages
+    full_document.scan(%r{\[.*?\]\((\/.*)(#.*)\)})
+      .map { |base, anchor| [base + anchor, valid_base_link?(base)] }
+      .to_h
+  end
+
+  # Match all anchor tags on current article
+  def anchor_tags_current_page
+    full_document.scan(/\[.*?\]\((#.*)\)/).flatten
+  end
+
+  def safe_url_parser(link)
+    URI.parse(link)
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def link_params(link)
+    options[:article_params].merge(url: link)
+  end
+
+  def anchor_tag?(link)
+    permalinks.include?(link)
+  end
+
+  def valid_external_anchor_tag?(link)
+    return false unless external_permalinks
+    external_permalinks[link]
+  end
+
+  def valid_base_link?(link)
+    internal_link?(link) || valid_article?(link)
+  end
+
+  def build_links?
+    options[:build_links]
+  end
+end

--- a/spec/services/article_links_service_spec.rb
+++ b/spec/services/article_links_service_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe ArticleLinksService do
       [anchor-link-above](#anchor-link-above)
       [anchor-link-below](#anchor-link-below)
 
+      ### anchor-tag, other page
+      [3](/#search)
+
       ### broken-link-tag-2
       [2](/tags/broken-link-tag-2)
 

--- a/spec/services/article_parser_service_spec.rb
+++ b/spec/services/article_parser_service_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "uri"
+require "rails_helper"
+
+RSpec.describe ArticleParserService do
+  let(:valid_link) { "[root_url](/)" }
+  let(:invalid_link) { "[broken](/tags/broken-link)" }
+
+  let(:full_document) do
+    <<~END
+      # Full Markdown Document Sample
+
+      ## Valid link
+      #{valid_link}
+
+      ## Invalid link
+      #{invalid_link}
+    END
+  end
+  let(:article_parser) { ArticleParserService.new({}, full_document) }
+
+  let(:mock_uri_valid)   { double("uri", host: "test.com", port: "80", uri: "/", absolute?: false) }
+  let(:mock_uri_invalid) { double("uri", host: "test.com", port: "80", uri: "/tags/broken-link") }
+
+  describe "#article_link_status" do
+    context "article found" do
+      before do
+        allow_any_instance_of(ArticleParserService)
+          .to(receive(:valid_article?)
+          .and_return(true))
+      end
+
+      it "returns no class" do
+        status = article_parser.article_link_status(valid_link)
+        expect(status).to eq(nil)
+      end
+    end
+
+    context "article not found" do
+      before do
+        allow_any_instance_of(ArticleParserService)
+          .to(receive(:valid_article?)
+          .and_return(false))
+      end
+
+      it "returns 'article-not-found' class" do
+        status = article_parser.article_link_status(invalid_link)
+        expect(status).to eq("article-not-found")
+      end
+    end
+  end
+
+  describe "#internal_link?" do
+    it "returns true for internal links" do
+      allow_any_instance_of(ArticleParserService)
+        .to(receive(:safe_url_parser)
+        .with(valid_link)
+        .and_return(mock_uri_valid))
+
+      response = article_parser.internal_link?(valid_link)
+      expect(response).to eq(true)
+    end
+  end
+
+  describe "#valid_article?" do
+    it "returns false for internal links which are not articles" do
+      allow_any_instance_of(ArticleParserService)
+        .to(receive(:safe_url_parser)
+        .with(valid_link)
+        .and_return(mock_uri_valid))
+
+      response = article_parser.valid_article?(valid_link)
+      expect(response).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## Overview
- [x] Put article parsing logic in `html_with_pygments.rb` into separate service `article_parser_service.rb`.
- [x] Fixed 'broken link' parsing logic to allow for anchor links on external urls.
- [x] Added the `has_many :broken_links, dependent: :destroy` association for the `Article` model.

## Todo

- [x] Write specs for service's public interface
- [x] Document new service through comments, and specs
- [x] QA on staging